### PR TITLE
change delaytimes via cat

### DIFF
--- a/ubitx_20/cat_libs.ino
+++ b/ubitx_20/cat_libs.ino
@@ -181,7 +181,7 @@ void CatSetPTT(boolean isPTTOn, byte fromType)
 void CatVFOToggle(boolean isSendACK, byte fromType)
 {
   if (fromType != 2 && fromType != 3) {
-    menuVfoToggle(1);
+    menuVfoToggle(1, 0);
   }  
 
   if (isSendACK)
@@ -470,8 +470,8 @@ void WriteEEPRom_FT817(byte fromType)
         sideTone = (sideTonePitch * 50 + 300) + sideToneSub;
         printLineF2(F("Sidetone set! CAT"));
         EEPROM.put(CW_SIDETONE, sideTone);
-        delay(500);
-        printLine2("");
+        delay(300);                       //If timeout errors occur in the calling software, remove them
+        printLine2("");                   //Ham radio deluxe is the only one that supports this feature yet. and ham radio deluxe has wait time as greater than 500ms
       }
       break;
 
@@ -482,8 +482,8 @@ void WriteEEPRom_FT817(byte fromType)
         sideTone = (sideTonePitch * 50 + 300) + sideToneSub;
         printLineF2(F("Sidetone set! CAT"));
         EEPROM.put(CW_SIDETONE, sideTone);
-        delay(500);
-        printLine2("");
+        delay(300);                   //If timeout errors occur in the calling software, remove them
+        printLine2("");               //Ham radio deluxe is the only one that supports this feature yet. and ham radio deluxe has wait time as greater than 500ms
       }
       break;
 
@@ -502,7 +502,7 @@ void WriteEEPRom_FT817(byte fromType)
       cwDelayTime = CAT_BUFF[2];
       printLineF2(F("CW Speed set!"));
       EEPROM.put(CW_DELAY, cwDelayTime);
-      delay(500);
+      delay(300);
       printLine2("");
       break;
     case 0x62 : //
@@ -511,7 +511,7 @@ void WriteEEPRom_FT817(byte fromType)
       cwSpeed = 1200 / ((CAT_BUFF[2] & 0x3F) + 4);
       printLineF2(F("CW Speed set!"));
       EEPROM.put(CW_SPEED, cwSpeed);
-      delay(500);
+      delay(300);
       printLine2("");
 
       break;
@@ -629,7 +629,6 @@ void Check_Cat(byte fromType)
   }
   else if (Serial.available() < 5)
   {
-    /*
     //First Arrived
     if (rxBufferCheckCount == 0)
     {
@@ -649,8 +648,6 @@ void Check_Cat(byte fromType)
       rxBufferCheckCount = Serial.available();
       rxBufferArriveTime = millis() + CAT_RECEIVE_TIMEOUT;  //Set time for timeout
     }
-    */
-    
     return;
   }
 

--- a/ubitx_20/ubitx_menu.ino
+++ b/ubitx_20/ubitx_menu.ino
@@ -155,7 +155,7 @@ void byteWithFreqToMode(byte modeValue){
     isUSB = 0;
 }
 
-void menuVfoToggle(int btn)
+void menuVfoToggle(int btn, char isUseDelayTime)
 {
   if (!btn){
     if (vfoActive == VFO_A)
@@ -189,8 +189,9 @@ void menuVfoToggle(int btn)
 
       ritDisable();
 
-      //updateDisplay();
-      delay_background(500, 0);
+      if (isUseDelayTime == 1)        //Found Issue in wsjt-x Linux 32bit 
+        delay_background(500, 0);
+        
       printLine2ClearAndUpdate();
       //exit the menu
       menuOn = 0;
@@ -803,7 +804,7 @@ void doMenu(){
     else if (select < 20)
       menuRitToggle(btnState);
     else if (select < 30)
-      menuVfoToggle(btnState);
+      menuVfoToggle(btnState, 1);
     else if (select < 40)
       menuSidebandToggle(btnState);
     else if (select < 50)


### PR DESCRIPTION
modified delay time routine via cat,
On Linux, may want faster response times in some programs.
So all the functions that are executed via cat have immediate response without delay time.
Also, the logic that automatically recovers when the protocol is broken is also uncommented.
