### PR TITLE
Compiler error in Linux due to case sensitive filenames.

### DIFF
--- a/ubitx_20/softserial_tiny.cpp
+++ b/ubitx_20/softserial_tiny.cpp
@@ -70,7 +70,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 The latest version of this library can always be found at
 http://arduiniana.org.
  */
-#include <arduino.h>
+#include <Arduino.h>
 
 //================================================================
 //Public Variable


### PR DESCRIPTION
ubitx_20/softserial_tiny.cpp:73 fatal error: arduino.h: No such file or directory

 #include <arduino.h>

Changing the include to Arduino.h solves the problem.