### PR TITLE
Use LOWEST_FREQ and HIGHEST_FREQ when changing bands

### DIFF
--- a/ubitx_20/ubitx_menu.ino
+++ b/ubitx_20/ubitx_menu.ino
@@ -104,9 +104,9 @@ void menuBand(int btn){
         }
       }       //end of only ham band move
       else {  //original source
-        if (knob < 0 && frequency > 3000000l)
+        if (knob < 0 && frequency > LOWEST_FREQ)
           setFrequency(frequency - 200000l);
-        if (knob > 0 && frequency < 30000000l)
+        if (knob > 0 && frequency < HIGHEST_FREQ)
           setFrequency(frequency + 200000l);
 
         if (frequency > 10000000l)


### PR DESCRIPTION
The band change code uses hard-coded values instead of the constants defined in ubitx_20.ino.  If you expand the working range of the radio the fast band switching does not work in the extended area.  This fix should let the speed tuning work no matter what the tuning range is set to.